### PR TITLE
Fixing ordering of a sample from a multi-output OILMM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearMixingModels"
 uuid = "b8ce4b42-e81b-4a39-a84a-67f74a9a16dd"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/oilmm.jl
+++ b/src/oilmm.jl
@@ -44,10 +44,10 @@ function AbstractGPs.rand(rng::AbstractRNG, fx::FiniteGP{<:OILMM})
     U, S = H.U, H.S
 
     # Generate from the latent processes.
-    X = hcat(map(f -> rand(rng, f(x)), fs.fs)...)
+    X = reshape(reduce(vcat, map(f -> rand(rng, f(x)), fs.fs)), :, length(x))
 
     # Transform latents into observed space.
-    F = vec(U * sqrt(S) * X')
+    F = vec(U * sqrt(S) * X)
 
     # Generate iid noise and add to each output.
     return F .+ sqrt(noise_var(fx.Σy)) .* randn(rng, size(F))

--- a/test/ilmm.jl
+++ b/test/ilmm.jl
@@ -11,6 +11,7 @@ function test_ilmm(rng, kernels, H, x_train, x_test, y_train, y_test)
     @test isapprox(var(ilmmx), var(n_ilmmx))
     @test isapprox(logpdf(ilmmx, y_train), logpdf(n_ilmmx, y_train))
     @test _is_approx(marginals(ilmmx), marginals(n_ilmmx))
+    @test length(rand(rng, ilmmx)) == size(H, 1) * length(x_train.x)
 
     p_ilmmx = posterior(ilmmx, y_train)
     p_n_ilmmx = posterior(n_ilmmx, y_train)
@@ -22,6 +23,7 @@ function test_ilmm(rng, kernels, H, x_train, x_test, y_train, y_test)
     @test isapprox(var(pi), var(pni))
     @test isapprox(logpdf(pi, y_test), logpdf(pni, y_test))
     @test _is_approx(marginals(pi), marginals(pni))
+    @test length(rand(rng, pi)) == size(H, 1) * length(x_test.x)
 
     @testset "primary_public_interface" begin
         test_finitegp_primary_public_interface(rng, ilmmx)
@@ -43,12 +45,6 @@ end
         H = rand(3, 2)
         k1, k2 = SEKernel(), Matern32Kernel()
         test_ilmm(rng, [k1, k2], H, x_train, x_test, y_train, y_test)
-    end
-
-    @testset "1 Latent Processes" begin
-        H = rand(3, 1)
-        k = SEKernel()
-        test_ilmm(rng, [k], H, x_train, x_test, y_train, y_test)
 
         @testset "util" begin
             Σ = Diagonal(Fill(2, 3))
@@ -67,6 +63,12 @@ end
 
             @test get_latent_gp(ilmm) == fs
         end
+    end
+
+    @testset "1 Latent Processes" begin
+        H = rand(3, 1)
+        k = SEKernel()
+        test_ilmm(rng, [k], H, x_train, x_test, y_train, y_test)
     end
 end
 @info "Ran ilmm tests."

--- a/test/independent_mogp.jl
+++ b/test/independent_mogp.jl
@@ -43,6 +43,7 @@
     @test marginals(fx) == vcat(marginals(fx1), marginals(fx2))
     @test isapprox(mean(fx), vcat(mean(fx1), mean(fx2)))
     @test isapprox(var(fx), vcat(var(fx1), var(fx2)))
+    @test length(rand(rng, fx)) == length(f.fs) * length(x_train_mo.x)
 
     pfx = posterior(fx, y_train)
     pfx1 = posterior(fx1, y_1_train)
@@ -57,6 +58,7 @@
     @test marginals(post_fx) == vcat(marginals(post_fx1), marginals(post_fx2))
     @test isapprox(mean(post_fx), vcat(mean(post_fx1), mean(post_fx2)))
     @test isapprox(var(post_fx), vcat(var(post_fx1), var(post_fx2)))
+    @test length(rand(rng, post_fx)) == length(f.fs) * length(x_test_mo.x)
 
     @testset "primary_public_interface" begin
         test_finitegp_primary_public_interface(rng, fx)

--- a/test/oilmm.jl
+++ b/test/oilmm.jl
@@ -11,6 +11,7 @@ function test_oilmm(rng, kernels, H::Orthogonal, x_train, x_test, y_train, y_tes
     @test isapprox(var(ilmmx), var(oilmmx))
     @test isapprox(logpdf(ilmmx, y_train), logpdf(oilmmx, y_train))
     @test _is_approx(marginals(ilmmx), marginals(oilmmx))
+    @test length(rand(rng, oilmmx)) == size(H, 1) * length(x_train.x)
 
     p_ilmmx = posterior(ilmmx, y_train)
     p_oilmmx = posterior(oilmmx, y_train)
@@ -22,6 +23,7 @@ function test_oilmm(rng, kernels, H::Orthogonal, x_train, x_test, y_train, y_tes
     @test isapprox(var(pi), var(po))
     @test isapprox(logpdf(pi, y_test), logpdf(po, y_test))
     @test _is_approx(marginals(pi), marginals(po))
+    @test length(rand(rng, po)) == size(H, 1) * length(x_test.x)
 
     @testset "primary_public_interface" begin
         test_finitegp_primary_public_interface(rng, oilmmx)


### PR DESCRIPTION
See screenshots of an example of a 2 output finite gp prior sample (outputs concatenated) below. Comparison with equivalent ILMM for reference (what it should sort of look like)

Before:
<img width="596" alt="Screen Shot 2021-08-24 at 10 14 23 AM" src="https://user-images.githubusercontent.com/50252341/130591107-cf910731-1997-436e-9e5c-f8c3cf1bf3a1.png">

After:
<img width="596" alt="Screen Shot 2021-08-24 at 10 13 58 AM" src="https://user-images.githubusercontent.com/50252341/130591257-626ce035-761d-42c8-a957-52310cf3514d.png">
