### PR TITLE
Restrict logpdf to real numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearMixingModels"
 uuid = "b8ce4b42-e81b-4a39-a84a-67f74a9a16dd"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/independent_mogp.jl
+++ b/src/independent_mogp.jl
@@ -73,7 +73,7 @@ function AbstractGPs.cov(
 end
 
 # See AbstractGPs.jl API docs.
-function AbstractGPs.logpdf(ft::IsotropicFiniteIndependentMOGP, y::AbstractVector)
+function AbstractGPs.logpdf(ft::IsotropicFiniteIndependentMOGP, y::AbstractVector{<:Real})
     finiteGPs = finite_gps(ft, ft.Σy[1])
     ys = collect(eachcol(reshape(y, (length(ft.x.x), :))))
     return sum(map(logpdf, finiteGPs, ys))


### PR DESCRIPTION
We should have been doing this anyway -- not restricting was an oversight.

Resolves #41 