### PR TITLE
Fix bug and generalise functionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearMixingModels"
 uuid = "b8ce4b42-e81b-4a39-a84a-67f74a9a16dd"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/independent_mogp.jl
+++ b/src/independent_mogp.jl
@@ -144,7 +144,7 @@ function reorder_by_outputs(Σy::Diagonal{<:Real}, x::MOInputIsotopicByFeatures)
     return Diagonal(Σy.diag[indices_which_reorder_features_to_outputs(x)])
 end
 
-reorder_by_outputs(Σy::Diagonal{<:Real, <:Fill}, x::MOInputIsotopicByFeatures) = Σy
+reorder_by_outputs(Σy::Diagonal{<:Real,<:Fill}, x::MOInputIsotopicByFeatures) = Σy
 
 function reorder_by_outputs(
     fx::FiniteGP{<:IndependentMOGP,<:MOInputIsotopicByFeatures,<:Diagonal{<:Real}}

--- a/src/independent_mogp.jl
+++ b/src/independent_mogp.jl
@@ -140,9 +140,16 @@ end
 
 reorder_by_outputs(x::MOInputIsotopicByFeatures) = MOInputIsotopicByOutputs(x.x, x.out_dim)
 
-# We know that the observation noise covariance is constant-diagonal, so no need to reorder.
-function reorder_by_outputs(fx::IsotropicByFeaturesFiniteIndependentMOGP)
-    return FiniteGP(fx.f, reorder_by_outputs(fx.x), fx.Σy)
+function reorder_by_outputs(Σy::Diagonal{<:Real}, x::MOInputIsotopicByFeatures)
+    return Diagonal(Σy.diag[indices_which_reorder_features_to_outputs(x)])
+end
+
+reorder_by_outputs(Σy::Diagonal{<:Real, <:Fill}, x::MOInputIsotopicByFeatures) = Σy
+
+function reorder_by_outputs(
+    fx::FiniteGP{<:IndependentMOGP,<:MOInputIsotopicByFeatures,<:Diagonal{<:Real}}
+)
+    return FiniteGP(fx.f, reorder_by_outputs(fx.x), reorder_by_outputs(fx.Σy, fx.x))
 end
 
 @non_differentiable indices_which_reorder_features_to_outputs(::Any)
@@ -206,7 +213,8 @@ function AbstractGPs.rand(rng::AbstractRNG, ft::IsotropicByFeaturesFiniteIndepen
 end
 
 function AbstractGPs.logpdf(
-    ft::FiniteGP{<:IndependentMOGP,<:MOInputIsotopicByFeatures}, y::AbstractVector{<:Real}
+    ft::FiniteGP{<:IndependentMOGP,<:MOInputIsotopicByFeatures,<:Diagonal{<:Real}},
+    y::AbstractVector{<:Real},
 )
     return logpdf(
         reorder_by_outputs(ft), y[indices_which_reorder_features_to_outputs(ft.x)]

--- a/test/independent_mogp.jl
+++ b/test/independent_mogp.jl
@@ -82,7 +82,6 @@
         rng = MersenneTwister(123456)
         kernels = [SEKernel(), 0.5 * LinearKernel()]
         f = IndependentMOGP(map(GP, kernels))
-        Σy = 0.1
 
         # Build an equivalent naive version of the GP and compare against it.
         f_naive = GP(LinearMixingModelKernel(kernels, Matrix{Float64}(I, 2, 2)))

--- a/test/independent_mogp.jl
+++ b/test/independent_mogp.jl
@@ -87,15 +87,15 @@
         # Build an equivalent naive version of the GP and compare against it.
         f_naive = GP(LinearMixingModelKernel(kernels, Matrix{Float64}(I, 2, 2)))
 
-        # Construct different noise models to work with.
-        Σy_iso = 0.1
-        Σy_diag = Diagonal(ones(length(x)) + rand(length(x)))
-        Σy_dense = let
-            A = randn(length(x), length(x))
-            Symmetric(A'A + I)
-        end
-
-        @testset "$(typeof(Σy))" for Σy in [Σy_iso, Σy_diag, Σy_dense]
+        # Test under various kinds of observation covariance matrix.
+        @testset "$(typeof(Σy))" for Σy in [
+            0.1,
+            Diagonal(ones(length(x)) + rand(length(x))),
+            let
+                A = randn(length(x), length(x))
+                Symmetric(A'A + I)
+            end,
+        ]
             fx = f(x, Σy)
             fx_naive = f_naive(x, Σy)
 


### PR DESCRIPTION
On master, if a dense observation covariance matrix is passed to a `FiniteGP` containing an `IndependentMOGP` and `MOInputIsotopicByFeatures` inputs, an error is thrown. This was a bug I introduced in 0.1.8, and it wasn't picked up because we weren't testing non-constant-diagonal observation noises with this configuration.

We also weren't handling `Diagonal` observation covariance matrices properly in this setting. This PR ensures something sensible happens when they're encountered. The functionality for handling `Diagonal` observation covariance matrices still isn't as general as we could make it in the `MOInputIsotopicByOutputs` case, but we can address that in a future PR.

