### PR TITLE
Fix Permutation Bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearMixingModels"
 uuid = "b8ce4b42-e81b-4a39-a84a-67f74a9a16dd"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/test/independent_mogp.jl
+++ b/test/independent_mogp.jl
@@ -76,11 +76,34 @@
     @testset "MOInputIsotopicByFeatures" begin
 
         # Inputs are isotopic and grouped by feature.
-        x = MOInputIsotopicByFeatures(collect(range(0.0, 2.0; length=2)), 2)
+        x = MOInputIsotopicByFeatures(collect(range(0.0, 2.0; length=3)), 2)
+
+        @testset "indices for reordering" begin
+
+            # Specific case where we know the answer.
+            v_by_output = [1, 1, 1, 2, 2, 2]
+            v_by_features = [1, 2, 1, 2, 1, 2]
+            inds_outputs_to_features = indices_which_reorder_outputs_to_features(x)
+            inds_features_to_outputs = indices_which_reorder_features_to_outputs(x)
+            @test v_by_output[inds_outputs_to_features] == v_by_features
+            @test v_by_features[inds_features_to_outputs] == v_by_output
+            @test ==(
+                v_by_output[inds_outputs_to_features][inds_features_to_outputs], v_by_output
+            )
+            @test ==(
+                v_by_features[inds_features_to_outputs][inds_outputs_to_features],
+                v_by_features,
+            )
+
+            # In the context of actual data.
+            x_by_outputs = MOInputIsotopicByOutputs(x.x, 2)
+            @test collect(x)[inds_features_to_outputs] == collect(x_by_outputs)
+            @test collect(x_by_outputs)[inds_outputs_to_features] == collect(x)
+        end
 
         # Build a test case.
         rng = MersenneTwister(123456)
-        kernels = [SEKernel(), 0.5 * LinearKernel()]
+        kernels = [SEKernel(), 0.5 * SEKernel()]
         f = IndependentMOGP(map(GP, kernels))
 
         # Build an equivalent naive version of the GP and compare against it.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,32 +31,32 @@ include("test_utils.jl")
 
 @testset "LinearMixingModels.jl" begin
     include("independent_mogp.jl")
-    # include("orthogonal_matrix.jl")
-    # include("ilmm.jl")
-    # include("oilmm.jl")
+    include("orthogonal_matrix.jl")
+    include("ilmm.jl")
+    include("oilmm.jl")
 
-    # @testset "doctests" begin
-    #     DocMeta.setdocmeta!(
-    #         LinearMixingModels,
-    #         :DocTestSetup,
-    #         quote
-    #             using AbstractGPs
-    #             using KernelFunctions
-    #             using LinearMixingModels
-    #             using Random
-    #             using LinearAlgebra
-    #             using FillArrays
-    #         end;
-    #         recursive=true,
-    #     )
-    #     doctest(
-    #         LinearMixingModels;
-    #         doctestfilters=[
-    #             r"{([a-zA-Z0-9]+,\s?)+[a-zA-Z0-9]+}",
-    #             r"(Array{[a-zA-Z0-9]+,\s?1}|\s?Vector{[a-zA-Z0-9]+})",
-    #             r"(Array{[a-zA-Z0-9]+,\s?2}|\s?Matrix{[a-zA-Z0-9]+})",
-    #         ],
-    #     )
-    # end
-    # @info "Ran doctests."
+    @testset "doctests" begin
+        DocMeta.setdocmeta!(
+            LinearMixingModels,
+            :DocTestSetup,
+            quote
+                using AbstractGPs
+                using KernelFunctions
+                using LinearMixingModels
+                using Random
+                using LinearAlgebra
+                using FillArrays
+            end;
+            recursive=true,
+        )
+        doctest(
+            LinearMixingModels;
+            doctestfilters=[
+                r"{([a-zA-Z0-9]+,\s?)+[a-zA-Z0-9]+}",
+                r"(Array{[a-zA-Z0-9]+,\s?1}|\s?Vector{[a-zA-Z0-9]+})",
+                r"(Array{[a-zA-Z0-9]+,\s?2}|\s?Matrix{[a-zA-Z0-9]+})",
+            ],
+        )
+    end
+    @info "Ran doctests."
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,13 @@ using AbstractGPs.TestUtils:
     test_finitegp_primary_and_secondary_public_interface,
     test_internal_abstractgps_interface
 using KernelFunctions: MOInputIsotopicByOutputs, MOInputIsotopicByFeatures
-using LinearMixingModels: unpack, noise_var, get_latent_gp, reshape_y
+using LinearMixingModels:
+    unpack,
+    noise_var,
+    get_latent_gp,
+    reshape_y,
+    indices_which_reorder_outputs_to_features,
+    indices_which_reorder_features_to_outputs
 
 function _is_approx(x::AbstractVector{<:Normal}, y::AbstractVector{<:Normal})
     return (map(mean, x) ≈ map(mean, y)) && (map(std, x) ≈ map(std, y))
@@ -25,32 +31,32 @@ include("test_utils.jl")
 
 @testset "LinearMixingModels.jl" begin
     include("independent_mogp.jl")
-    include("orthogonal_matrix.jl")
-    include("ilmm.jl")
-    include("oilmm.jl")
+    # include("orthogonal_matrix.jl")
+    # include("ilmm.jl")
+    # include("oilmm.jl")
 
-    @testset "doctests" begin
-        DocMeta.setdocmeta!(
-            LinearMixingModels,
-            :DocTestSetup,
-            quote
-                using AbstractGPs
-                using KernelFunctions
-                using LinearMixingModels
-                using Random
-                using LinearAlgebra
-                using FillArrays
-            end;
-            recursive=true,
-        )
-        doctest(
-            LinearMixingModels;
-            doctestfilters=[
-                r"{([a-zA-Z0-9]+,\s?)+[a-zA-Z0-9]+}",
-                r"(Array{[a-zA-Z0-9]+,\s?1}|\s?Vector{[a-zA-Z0-9]+})",
-                r"(Array{[a-zA-Z0-9]+,\s?2}|\s?Matrix{[a-zA-Z0-9]+})",
-            ],
-        )
-    end
-    @info "Ran doctests."
+    # @testset "doctests" begin
+    #     DocMeta.setdocmeta!(
+    #         LinearMixingModels,
+    #         :DocTestSetup,
+    #         quote
+    #             using AbstractGPs
+    #             using KernelFunctions
+    #             using LinearMixingModels
+    #             using Random
+    #             using LinearAlgebra
+    #             using FillArrays
+    #         end;
+    #         recursive=true,
+    #     )
+    #     doctest(
+    #         LinearMixingModels;
+    #         doctestfilters=[
+    #             r"{([a-zA-Z0-9]+,\s?)+[a-zA-Z0-9]+}",
+    #             r"(Array{[a-zA-Z0-9]+,\s?1}|\s?Vector{[a-zA-Z0-9]+})",
+    #             r"(Array{[a-zA-Z0-9]+,\s?2}|\s?Matrix{[a-zA-Z0-9]+})",
+    #         ],
+    #     )
+    # end
+    # @info "Ran doctests."
 end


### PR DESCRIPTION
I guess permutations are hard? Looks like a test involving a length-4 `MOIsotopicByFeatures` with 2 output dimensions is a special case -- the moment you generalise to more things, things start to break.

This PR fixes the bug, adds more thorough unit testing of the permutation functionality, and renames things to reflect what they're actually doing (as opposed to what we thought they are doing).